### PR TITLE
fix(ListField): Get accessor fixed to return list of values (closes #5)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "typed-models"
-version = "0.2.2"
+version = "0.2.3"
 description = "Strongly typed, lightweight, serializable models for Python"
 authors = ["Imtiaz Mangerah <Imtiaz_Mangerah@a2d24.com>"]
 license = "MIT"

--- a/tests/fields/test_list.py
+++ b/tests/fields/test_list.py
@@ -44,9 +44,9 @@ def test_strongly_typed_list():
     now_in_utc = now.in_tz('UTC')
     result = field.parse(['2020-01-01', '2020-01-02T22:10+0200', now])
 
-    assert_datetime(result[0].get(), 2020, 1, 1)
-    assert_datetime(result[1].get(), 2020, 1, 2, hour=20, minute=10)
-    assert_datetime(result[2].get(),
+    assert_datetime(result[0], 2020, 1, 1)
+    assert_datetime(result[1], 2020, 1, 2, hour=20, minute=10)
+    assert_datetime(result[2],
                     now_in_utc.year,
                     now_in_utc.month,
                     now_in_utc.day,
@@ -68,6 +68,12 @@ def test_can_append_with_strong_typing_to_empty_list():
     typed_list.append('2020-01-01')
     typed_list.append('2020-01-02')
 
+def test_list_get_accessor_returns_list_of_internal_values():
+    field = ListField(list_type=StringField())
+    value = FieldValue(field=field)
+    value.set(["Hello", "World"])
+
+    assert list(value.get()) == ["Hello", "World"]
 
 def test_serializer():
     field = ListField(list_type=DateTimeField(tz='UTC'))
@@ -102,13 +108,13 @@ def test_can_delete_item():
 
     del list[2]
 
-    assert [l.get() for l in list] == ['Hello', 'World']
+    assert [l for l in list] == ['Hello', 'World']
 
 def test_can_replace_item():
     field = ListField(list_type=StringField())
-    list = field.parse(['Hello', 'Wrong'])
-    list[1] = 'World'
-    assert [l.get() for l in list] == ['Hello', 'World']
+    l = field.parse(['Hello', 'Wrong'])
+    l[1] = 'World'
+    assert list(l) == ['Hello', 'World']
 
 def test_list_str_representation():
     field = ListField(list_type=StringField())

--- a/typed_models/base.py
+++ b/typed_models/base.py
@@ -39,6 +39,11 @@ class Field:
         raise ValueError(
             f'Field "{self.field_name}" with value "{value}" could not be parsed as a {self.__class__.__name__}') from None
 
+    def get(self, field_value):
+        return field_value.get()
+
+    def set(self, field_value, value):
+        field_value.set(value)
 
 class FieldValue:
 
@@ -109,7 +114,7 @@ class Model(metaclass=ModelMeta):
             except KeyError:
                 value = field.get_default()
 
-            field_value.set(value)
+            field.set(field_value, value)
 
             self._field_values[field_name] = field_value
 
@@ -120,8 +125,9 @@ class Model(metaclass=ModelMeta):
         if item not in self._model_meta['fields']:
             return super().__getattribute__(item)
 
+        field: Field = self._model_meta['fields'][item]
         field_value: FieldValue = self._field_values[item]
-        return field_value.get()
+        return field.get(field_value)
 
     def __setattr__(self, key, value):
 
@@ -129,8 +135,10 @@ class Model(metaclass=ModelMeta):
             super().__setattr__(key, value)
             return
 
+        field: Field = self._model_meta['fields'][key]
+
         field_value: FieldValue = self._field_values[key]
-        field_value.set(value)
+        field.set(field_value, value)
 
     def serialize(self, serializer=DefaultSerializer):
         return serializer.serialize(self)

--- a/typed_models/fields/list.py
+++ b/typed_models/fields/list.py
@@ -32,12 +32,13 @@ class ListField(Field):
 
     def serialize(self, value, serializer=NOT_PROVIDED):
         if serializer is NOT_PROVIDED:
-            return [self.ListType.default_serializer(v.get()) for v in value]
+            return [self.ListType.default_serializer(v) for v in value]
 
         if isinstance(self.ListType, ModelField):
-            return [serializer.serialize(v.get()) for v in value]
+            return [serializer.serialize(v) for v in value]
 
-        return [serializer.serialize_field(v) for v in value]
+        raw_fields = [value.get_raw(i) for i in range(len(value))]
+        return [serializer.serialize_field(v) for v in raw_fields]
 
 
 class TypedFieldList(MutableSequence):
@@ -51,7 +52,7 @@ class TypedFieldList(MutableSequence):
         return len(self.list)
 
     def __getitem__(self, i):
-        return self.list[i]
+        return self.list[i].get()
 
     def __delitem__(self, i):
         del self.list[i]
@@ -66,6 +67,9 @@ class TypedFieldList(MutableSequence):
         field_value.set(v)
 
         self.list.insert(i, field_value)
+
+    def get_raw(self, i):
+        return self.list[i]
 
     def __str__(self):
         return str([str(i.get()) for i in self.list])


### PR DESCRIPTION
The get accessor of ListField returned a list of FieldValues instead of values. This meant that the list could not be worked with directly and  required a .get() call to each value to fetch the value. This PR fixes the behaviour.